### PR TITLE
Drink detail

### DIFF
--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Localizable.xcstrings
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "+ %@" : {
+
+    },
     "Add to cart" : {
 
     },
@@ -201,9 +204,6 @@
           }
         }
       }
-    },
-    "numberShots.1" : {
-
     },
     "orxataDescription" : {
       "extractionState" : "manual",

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Localizable.xcstrings
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Localizable.xcstrings
@@ -216,9 +216,6 @@
         }
       }
     },
-    "Rate drink" : {
-
-    },
     "Rate your drink" : {
 
     },

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Localizable.xcstrings
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Localizable.xcstrings
@@ -1,0 +1,274 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Add to cart" : {
+
+    },
+    "addToCart" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add to Cart"
+          }
+        }
+      }
+    },
+    "appName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NSCoffee"
+          }
+        }
+      }
+    },
+    "buy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy"
+          }
+        }
+      }
+    },
+    "chaiDescription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drink made with black tea, spices, milk, and sweetener, topped with foam."
+          }
+        }
+      }
+    },
+    "chocolateDescription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hot drink made with melted or shaved chocolate, milk or water, and sweetener"
+          }
+        }
+      }
+    },
+    "coffee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coffees"
+          }
+        }
+      }
+    },
+    "Coffees" : {
+
+    },
+    "Cold Drinks" : {
+
+    },
+    "coldBrewDescription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cold brew coffee is coffee that's steeped in cold or room temperature water for a long time, usually 12–24 hours."
+          }
+        }
+      }
+    },
+    "coldDrink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cold Drinks"
+          }
+        }
+      }
+    },
+    "cortadoDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A cortado is a Spanish beverage consisting of espresso mixed with a roughly equal amount of warm milk to reduce the acidity."
+          }
+        }
+      }
+    },
+    "espressoDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concentrated form of coffee produced by forcing hot water under high pressure through finely ground coffee beans."
+          }
+        }
+      }
+    },
+    "Extra Shots" : {
+
+    },
+    "flatWhiteDescription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A flat white is a blend of micro-foamed milk poured over a single or double shot of espresso."
+          }
+        }
+      }
+    },
+    "frappeDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Greek iced coffee drink generally made from spray-dried instant coffee, water, sugar, and milk."
+          }
+        }
+      }
+    },
+    "Hot Drinks" : {
+
+    },
+    "hotDrink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hot Drinks"
+          }
+        }
+      }
+    },
+    "latteDescription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A latte is a coffee drink made with espresso, steamed milk, and a thin layer of foam."
+          }
+        }
+      }
+    },
+    "macchiatoDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espresso coffee drink with a small amount of milk, usually foamed."
+          }
+        }
+      }
+    },
+    "NSCoffee" : {
+
+    },
+    "numberShots.%lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld shot"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld shots"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "numberShots.1" : {
+
+    },
+    "orxataDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sweet, refreshing drink from Valencia, Spain, made from tiger nuts, water, and sugar. It's often served cold in the summer. "
+          }
+        }
+      }
+    },
+    "Rate drink" : {
+
+    },
+    "Rate your drink" : {
+
+    },
+    "spanishLatteDescription" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coffee drink made with espresso, milk, and sweetened condensed milk."
+          }
+        }
+      }
+    },
+    "thumbsUp.%lld" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld thumb up"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld thumbs up"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Type of Milk" : {
+
+    },
+    "typeOfMilk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type of Milk"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Models/Drinks.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Models/Drinks.swift
@@ -31,53 +31,64 @@ struct Drinks {
         Coffee(name: "Espresso",
                description: String(localized: "espressoDescription"),
                basePrice: 2.0,
-               imageName: "Espresso"),
+               imageName: "Espresso",
+               shotPrice: 0.4),
         Coffee(name: "Macchiato",
                description: String(localized: "macchiatoDescription"),
                basePrice: 2.5,
-               imageName: "Macchiato"),
+               imageName: "Macchiato",
+               shotPrice: 0.5),
         Coffee(name: "Cortado",
                description: String(localized: "cortadoDescription"),
                basePrice: 2.8,
-               imageName: "Cortado"),
+               imageName: "Cortado",
+               shotPrice: 0.6),
         Coffee(name: "Flat White",
                description: String(localized: "flatWhiteDescription"),
                basePrice: 3.7,
-               imageName: "FlatWhite"),
+               imageName: "FlatWhite",
+               shotPrice: 0.75),
         Coffee(name: "Latte",
                description: String(localized: "latteDescription"),
                basePrice: 3.8,
-               imageName: "Latte"),
+               imageName: "Latte",
+               shotPrice: 0.75),
         Coffee(name: "Spanish Latte",
                description: String(localized: "spanishLatteDescription"),
                basePrice: 3.9,
-               imageName: "SpanishLatte")
+               imageName: "SpanishLatte",
+               shotPrice: 0.8)
     ]
 
     let hotDrinks = [
         HotDrink(name: "Chai Latte",
                  description: String(localized: "chaiDescription"),
                  basePrice: 3.2,
-                 imageName: "Chai"),
+                 imageName: "Chai",
+                 shotPrice: 0.65),
         HotDrink(name: "Hot Chocolate",
                  description: String(localized: "chocolateDescription"),
                  basePrice: 3.0,
-                 imageName: "HotChoc")
+                 imageName: "HotChoc",
+                 shotPrice: 0.6)
     ]
 
     let coldDrinks = [
         ColdDrink(name: "Cold Brew",
                   description: String(localized: "coldBrewDescription"),
                   basePrice: 3.7,
-                  imageName: "ColdBrew"),
+                  imageName: "ColdBrew",
+                  shotPrice: 0.75),
         ColdDrink(name: "Frappé",
                   description: String(localized: "frappeDescription"),
                   basePrice: 3.8,
-                  imageName: "Frappe"),
+                  imageName: "Frappe",
+                  shotPrice: 0.75),
         ColdDrink(name: "Orxata",
                   description: String(localized: "orxataDescription"),
                   basePrice: 3.25,
-                  imageName: "Orxata")
+                  imageName: "Orxata",
+                  shotPrice: 0.65)
     ]
 }
 
@@ -87,6 +98,7 @@ protocol Drink: Identifiable {
     var description: String { get }
     var basePrice: Double { get }
     var imageName: String? { get }
+    var shotPrice: Double { get }
 }
 
 struct Coffee: Drink {
@@ -95,6 +107,7 @@ struct Coffee: Drink {
     let description: String
     let basePrice: Double
     var imageName: String? = nil
+    let shotPrice: Double
 }
 
 struct HotDrink: Drink {
@@ -103,6 +116,7 @@ struct HotDrink: Drink {
     let description: String
     let basePrice: Double
     var imageName: String? = nil
+    let shotPrice: Double
 }
 
 struct ColdDrink: Drink {
@@ -111,4 +125,5 @@ struct ColdDrink: Drink {
     let description: String
     let basePrice: Double
     var imageName: String? = nil
+    let shotPrice: Double
 }

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct DrinkDetail: View {
     let drink: any Drink
-    @State private var milkExpanded = false
-    @State private var selectedMilk = MilkOptions.dairy
 
     var body: some View {
         List {
@@ -42,36 +40,7 @@ struct DrinkDetail: View {
                 RatingView()
             }
 
-            Section {
-                if milkExpanded {
-                    ForEach(MilkOptions.allCases, id: \.self) { milk in
-
-                        HStack {
-                            Text(milk.rawValue)
-
-                            Spacer()
-
-                            Image(systemName: selectedMilk == milk ? "checkmark.circle" : "circle")
-                                .accessibilityHidden(true)
-                        }
-                        .onTapGesture {
-                            selectedMilk = milk
-                        }
-                    }
-                }
-            } header: {
-                HStack {
-                    Text("Type of Milk")
-
-                    Image(systemName: "chevron.up")
-                        .rotationEffect(.degrees(milkExpanded ? 180 : 0))
-                }
-                .onTapGesture {
-                    withAnimation {
-                        milkExpanded.toggle()
-                    }
-                }
-            }
+            MilkTypeView()
         }
         .listStyle(.grouped)
         .navigationTitle(drink.name)

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
@@ -35,7 +35,7 @@ struct DrinkDetail: View {
             }
 
             Section("Extra Shots") {
-                Text("numberShots.1")
+                ExtraShotsView(shotPrice: drink.shotPrice)
             }
 
             Section("Rate your drink") {

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
@@ -1,0 +1,79 @@
+//
+//  DrinkDetail.swift
+//  NSCoffee
+//
+//  Created by Rob Whitaker on 02/03/2025.
+//
+
+import SwiftUI
+
+struct DrinkDetail: View {
+    let drink: any Drink
+    @State private var milkExpanded = false
+    @State private var selectedMilk = MilkOptions.dairy
+
+    var body: some View {
+        List {
+            ZStack {
+                if let imageName = drink.imageName {
+                    Image(imageName)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+
+                } else {
+                    Image(systemName: "cup.and.heat.waves.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                }
+
+                VStack {
+                    Spacer()
+
+                    Text(drink.description)
+                        .padding()
+                }
+            }
+
+            Section("Extra Shots") {
+                Text("numberShots.1")
+            }
+
+            Section("Rate your drink") {
+                Text("Rate drink")
+            }
+
+            Section {
+                if milkExpanded {
+                    ForEach(MilkOptions.allCases, id: \.self) { milk in
+
+                        HStack {
+                            Text(milk.rawValue)
+
+                            Spacer()
+
+                            Image(systemName: selectedMilk == milk ? "checkmark.circle" : "circle")
+                                .accessibilityHidden(true)
+                        }
+                        .onTapGesture {
+                            selectedMilk = milk
+                        }
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Type of Milk")
+
+                    Image(systemName: "chevron.up")
+                        .rotationEffect(.degrees(milkExpanded ? 180 : 0))
+                }
+                .onTapGesture {
+                    withAnimation {
+                        milkExpanded.toggle()
+                    }
+                }
+            }
+        }
+        .listStyle(.grouped)
+        .navigationTitle(drink.name)
+    }
+}

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
@@ -11,7 +11,6 @@ struct DrinkDetail: View {
     let drink: any Drink
     @State private var milkExpanded = false
     @State private var selectedMilk = MilkOptions.dairy
-    @State private var rating = 1
 
     var body: some View {
         List {
@@ -40,20 +39,7 @@ struct DrinkDetail: View {
             }
 
             Section("Rate your drink") {
-                HStack {
-                    ForEach(1..<6) { value in
-                        Button {
-                            rating = value
-
-                        } label: {
-                            Image(systemName: value <= rating ? "hand.thumbsup.fill" : "hand.thumbsup")
-                                .containerRelativeFrame(.horizontal, count: 12, span: 2, spacing: 10)
-                                .foregroundStyle(.tint)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal)
+                RatingView()
             }
 
             Section {

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
@@ -11,6 +11,7 @@ struct DrinkDetail: View {
     let drink: any Drink
     @State private var milkExpanded = false
     @State private var selectedMilk = MilkOptions.dairy
+    @State private var rating = 1
 
     var body: some View {
         List {
@@ -39,7 +40,20 @@ struct DrinkDetail: View {
             }
 
             Section("Rate your drink") {
-                Text("Rate drink")
+                HStack {
+                    ForEach(1..<6) { value in
+                        Button {
+                            rating = value
+
+                        } label: {
+                            Image(systemName: value <= rating ? "hand.thumbsup.fill" : "hand.thumbsup")
+                                .containerRelativeFrame(.horizontal, count: 12, span: 2, spacing: 10)
+                                .foregroundStyle(.tint)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal)
             }
 
             Section {

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkDetail.swift
@@ -13,16 +13,7 @@ struct DrinkDetail: View {
     var body: some View {
         List {
             ZStack {
-                if let imageName = drink.imageName {
-                    Image(imageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-
-                } else {
-                    Image(systemName: "cup.and.heat.waves.fill")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                }
+                DrinkTableImage(imageName: drink.imageName)
 
                 VStack {
                     Spacer()

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkTableImage.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkTableImage.swift
@@ -23,6 +23,5 @@ struct DrinkTableImage: View {
                     .aspectRatio(contentMode: .fit)
             }
         }
-        .containerRelativeFrame(.horizontal, count: 4, span: 1, spacing: 10)
     }
 }

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkTableRow.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkTableRow.swift
@@ -11,31 +11,42 @@ struct DrinkTableRow: View {
     let drink: any Drink
 
     var body: some View {
-        HStack {
-            DrinkTableImage(imageName: drink.imageName)
-                .padding(.trailing, 10)
+        ZStack {
 
-            VStack(alignment: .leading) {
-                Text(drink.name)
-                    .lineLimit(1)
+            HStack {
+                DrinkTableImage(imageName: drink.imageName)
+                    .padding(.trailing, 10)
 
-                Text(CurrencyFormatter.format(drink.basePrice))
-                    .font(.system(size: 17.0))
+                VStack(alignment: .leading) {
+                    Text(drink.name)
+                        .lineLimit(1)
 
-                Text("Add to cart")
-                    .bold()
-                    .padding(8)
-                    .background(.blue)
-                    .clipShape(.capsule)
-                    .onTapGesture {
-                        print("Added")
-                    }
+                    Text(CurrencyFormatter.format(drink.basePrice))
+                        .font(.system(size: 17.0))
+
+                    Text("Add to cart")
+                        .bold()
+                        .padding(8)
+                        .background(.blue)
+                        .clipShape(.capsule)
+                        .onTapGesture {
+                            print("Added")
+                        }
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(.tint)
             }
 
-            Spacer()
+            NavigationLink {
+                DrinkDetail(drink: drink)
 
-            Image(systemName: "chevron.right")
-                .foregroundStyle(.tint)
+            } label: {
+                EmptyView()
+            }
+            .opacity(0)
         }
     }
 }

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkTableRow.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/DrinkTableRow.swift
@@ -12,18 +12,18 @@ struct DrinkTableRow: View {
 
     var body: some View {
         ZStack {
-
             HStack {
                 DrinkTableImage(imageName: drink.imageName)
+                    .containerRelativeFrame(.horizontal, count: 4, span: 1, spacing: 10)
                     .padding(.trailing, 10)
 
                 VStack(alignment: .leading) {
                     Text(drink.name)
                         .lineLimit(1)
 
-                Text(CurrencyFormatter.format(drink.basePrice))
-                    .font(.system(size: 17.0))
-                    .foregroundStyle(Color(UIColor.darkGray))
+                    Text(CurrencyFormatter.format(drink.basePrice))
+                        .font(.system(size: 17.0))
+                        .foregroundStyle(Color(UIColor.darkGray))
 
                     Text("Add to cart")
                         .bold()
@@ -34,7 +34,7 @@ struct DrinkTableRow: View {
                             print("Added")
                         }
                 }
-
+                
                 Spacer()
 
                 Image(systemName: "chevron.right")

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/ExtraShotsView.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/ExtraShotsView.swift
@@ -1,0 +1,39 @@
+//
+//  ExtraShotsView.swift
+//  NSCoffee
+//
+//  Created by Rob Whitaker on 02/03/2025.
+//
+
+import SwiftUI
+
+struct ExtraShotsView: View {
+    let shotPrice: Double
+    @State private var shots = 1
+
+    private var extraShotPrice: Double {
+        (shotPrice * (Double(shots) - 1.0))
+    }
+
+    var body: some View {
+        HStack {
+            Image(systemName: "minus.circle")
+                .onTapGesture {
+                    guard shots > 1 else { return }
+                    shots -= 1
+                }
+                .foregroundStyle(.tint)
+
+            Text("numberShots.\(shots)")
+
+            Image(systemName: "plus.circle")
+                .onTapGesture {
+                    guard shots < 5 else { return }
+                    shots += 1
+                }
+                .foregroundStyle(.tint)
+
+            Text("+ \(CurrencyFormatter.format(extraShotPrice))")
+        }
+    }
+}

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/MilkTypeView.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/MilkTypeView.swift
@@ -1,0 +1,50 @@
+//
+//  MilkTypeView.swift
+//  NSCoffee
+//
+//  Created by Rob Whitaker on 02/03/2025.
+//
+
+import SwiftUI
+
+struct MilkTypeView: View {
+    @State private var milkExpanded = false
+    @State private var selectedMilk = MilkOptions.dairy
+    
+    var body: some View {
+        Section {
+            if milkExpanded {
+                ForEach(MilkOptions.allCases, id: \.self) { milk in
+
+                    HStack {
+                        Text(milk.rawValue)
+
+                        Spacer()
+
+                        Image(systemName: selectedMilk == milk ? "checkmark.circle" : "circle")
+                            .accessibilityHidden(true)
+                    }
+                    .onTapGesture {
+                        selectedMilk = milk
+                    }
+                }
+            }
+        } header: {
+            HStack {
+                Text("Type of Milk")
+
+                Image(systemName: "chevron.up")
+                    .rotationEffect(.degrees(milkExpanded ? 180 : 0))
+            }
+            .onTapGesture {
+                withAnimation {
+                    milkExpanded.toggle()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    MilkTypeView()
+}

--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/RatingView.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/RatingView.swift
@@ -1,0 +1,35 @@
+//
+//  RatingView.swift
+//  NSCoffee
+//
+//  Created by Rob Whitaker on 02/03/2025.
+//
+
+import SwiftUI
+
+struct RatingView: View {
+    @State private var rating = 1
+
+    var body: some View {
+        HStack {
+            ForEach(1..<6) { value in
+                Button {
+                    withAnimation {
+                        rating = value
+                    }
+
+                } label: {
+                    Image(systemName: value <= rating ? "hand.thumbsup.fill" : "hand.thumbsup")
+                        .containerRelativeFrame(.horizontal, count: 12, span: 2, spacing: 10)
+                        .foregroundStyle(.tint)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal)
+    }
+}
+
+#Preview {
+    RatingView()
+}


### PR DESCRIPTION
Added the drink detail screen
* Rating control
* Extra shots
* Milk type

Known issues - 
* The hero image has hz padding that I'm not sure how to remove
* There is currently no basket. Once I add this the screen will require some slight rearchitecting to calculate the drink price
* There are multiple places here where I've used onTapGesture because SwiftUI doesn't give the expected behaviour. This means I think I've overused onTapGesture throughout the app, so will look to replace some with Buttons where possible.

Check [Drinks.swift](https://github.com/dadederk/fromZeroToAccessible/compare/drink-detail?expand=1#diff-7de03ef787daf7d4c6b723304011e4cc4fb63337f90ee952c388c5833f1d6eb8) for details of the extra shot prices.

https://github.com/user-attachments/assets/f45d17f1-64e7-43f1-b223-8a3ca4499284


