### PR TITLE
removing disable of buy button, replaced with opacity

### DIFF
--- a/Z2A SwiftUI/NSCoffee/NSCoffee/Views/BasketView.swift
+++ b/Z2A SwiftUI/NSCoffee/NSCoffee/Views/BasketView.swift
@@ -30,11 +30,13 @@ struct BasketView: View {
                 Spacer()
 
                 Button {
-                    if basket.placeOrder() {
-                        toastMessage = "Order placed"
-                        
-                    } else {
-                        toastMessage = "Error placing order"
+                    if !basket.isEmpty {
+                        if basket.placeOrder() {
+                            toastMessage = "Order placed"
+
+                        } else {
+                            toastMessage = "Error placing order"
+                        }
                     }
 
                 } label: {
@@ -42,7 +44,7 @@ struct BasketView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(basket.isEmpty)
+                .opacity(basket.isEmpty ? 0.5 : 1.0)
         }
         .padding()
         .containerRelativeFrame(.horizontal, count: 4, span: 3, spacing: 0)


### PR DESCRIPTION
Removing the disable state from the buy button. Instead replacing with setting the opacity.
This is the closest I think I can get in SwiftUI to the behaviour in the UIKit app.