### PR TITLE
stacking shots price at larger sizes

### DIFF
--- a/Z2A SwiftUI/NSCoffee_withFixes/NSCoffee/Views/ExtraShotsView.swift
+++ b/Z2A SwiftUI/NSCoffee_withFixes/NSCoffee/Views/ExtraShotsView.swift
@@ -11,39 +11,56 @@ struct ExtraShotsView: View {
     let shotPrice: Double
     @State private var shots = 0
     @Binding var extras: [Extra]
+    @Environment(\.dynamicTypeSize.isAccessibilitySize) var accessibilitySize
 
     private var extraShotPrice: Double {
         shotPrice * Double(shots)
     }
 
+    private var extraShotPriceText: Text {
+        Text("+ \(CurrencyFormatter.format(extraShotPrice))")
+    }
+
     var body: some View {
-        HStack {
-            Image(systemName: "minus.circle")
-                .onTapGesture {
-                    guard shots > 0 else { return }
+        VStack {
+            HStack {
+                Image(systemName: "minus.circle")
+                    .onTapGesture {
+                        guard shots > 0 else { return }
 
-                    shots -= 1
+                        shots -= 1
 
-                    if shots == 0 {
-                        extras = []
-                    } else {
+                        if shots == 0 {
+                            extras = []
+                        } else {
+                            extras = [Extra(description: "Extra shot", price: shotPrice, quantity: shots)]
+                        }
+                    }
+                    .foregroundStyle(.tint)
+
+                Text("numberShots.\(shots)")
+
+                Image(systemName: "plus.circle")
+                    .onTapGesture {
+                        guard shots < 4 else { return }
+
+                        shots += 1
                         extras = [Extra(description: "Extra shot", price: shotPrice, quantity: shots)]
                     }
+                    .foregroundStyle(.tint)
+
+                /* Fix: At larger text sizes moving content
+                 stacked horizontally to being stacked
+                 vertically allows for improved readability
+                 */
+                if !accessibilitySize {
+                    extraShotPriceText
                 }
-                .foregroundStyle(.tint)
+            }
 
-            Text("numberShots.\(shots)")
-
-            Image(systemName: "plus.circle")
-                .onTapGesture {
-                    guard shots < 4 else { return }
-
-                    shots += 1
-                    extras = [Extra(description: "Extra shot", price: shotPrice, quantity: shots)]
-                }
-                .foregroundStyle(.tint)
-
-            Text("+ \(CurrencyFormatter.format(extraShotPrice))")
+            if accessibilitySize {
+                extraShotPriceText
+            }
         }
     }
 }

--- a/Z2A SwiftUI/NSCoffee_withFixes/NSCoffee/Views/ExtraShotsView.swift
+++ b/Z2A SwiftUI/NSCoffee_withFixes/NSCoffee/Views/ExtraShotsView.swift
@@ -48,12 +48,11 @@ struct ExtraShotsView: View {
         }
     }
 
-    /* Fix: At larger text sizes moving content
-     stacked horizontally to being stacked
-     vertically allows for improved readability
-     */
-
     var body: some View {
+        /* Fix: At larger text sizes moving content
+         stacked horizontally to being stacked
+         vertically allows for improved readability
+         */
         ViewThatFits {
             HStack {
                 shotControl

--- a/Z2A SwiftUI/NSCoffee_withFixes/NSCoffee/Views/ExtraShotsView.swift
+++ b/Z2A SwiftUI/NSCoffee_withFixes/NSCoffee/Views/ExtraShotsView.swift
@@ -21,42 +21,50 @@ struct ExtraShotsView: View {
         Text("+ \(CurrencyFormatter.format(extraShotPrice))")
     }
 
-    var body: some View {
-        VStack {
-            HStack {
-                Image(systemName: "minus.circle")
-                    .onTapGesture {
-                        guard shots > 0 else { return }
-                        shots -= 1
-                        if shots == 0 {
-                            extras = []
-                        } else {
-                            extras = [Extra(description: "Extra shot", price: shotPrice, quantity: Int(shots))]
-                        }
-                    }
-                    .foregroundStyle(.tint)
-
-                Text("numberShots.\(Int(shots))")
-
-                Image(systemName: "plus.circle")
-                    .onTapGesture {
-                        guard shots < 4 else { return }
-
-                        shots += 1
+    private var shotControl: some View {
+        Group {
+            Image(systemName: "minus.circle")
+                .onTapGesture {
+                    guard shots > 0 else { return }
+                    shots -= 1
+                    if shots == 0 {
+                        extras = []
+                    } else {
                         extras = [Extra(description: "Extra shot", price: shotPrice, quantity: Int(shots))]
                     }
-                    .foregroundStyle(.tint)
-
-                /* Fix: At larger text sizes moving content
-                 stacked horizontally to being stacked
-                 vertically allows for improved readability
-                 */
-                if !accessibilitySize {
-                    extraShotPriceText
                 }
+                .foregroundStyle(.tint)
+
+            Text("numberShots.\(Int(shots))")
+
+            Image(systemName: "plus.circle")
+                .onTapGesture {
+                    guard shots < 4 else { return }
+
+                    shots += 1
+                    extras = [Extra(description: "Extra shot", price: shotPrice, quantity: Int(shots))]
+                }
+                .foregroundStyle(.tint)
+        }
+    }
+
+    /* Fix: At larger text sizes moving content
+     stacked horizontally to being stacked
+     vertically allows for improved readability
+     */
+
+    var body: some View {
+        ViewThatFits {
+            HStack {
+                shotControl
+                extraShotPriceText
             }
 
-            if accessibilitySize {
+            VStack {
+                HStack {
+                    shotControl
+                }
+
                 extraShotPriceText
             }
         }


### PR DESCRIPTION
Shots text was cramped at larger text sizes, so moving the price below when an ax size is selected